### PR TITLE
Save project

### DIFF
--- a/client/components/ButtonBar.js
+++ b/client/components/ButtonBar.js
@@ -1,17 +1,26 @@
 import React, { Component } from 'react';
+import { saveProject } from '../store';
+import { connect } from 'react-redux';
 import { Toolbar } from 'primereact/toolbar';
 import ClipButton from './ClipButton';
 import { Button } from 'primereact/button';
 
-export default class ButtonBar extends Component {
-  constructor() {
-    super();
+class ButtonBar extends Component {
+  constructor(props) {
+    super(props);
     this.state = {};
     this.handleAddContainer = this.handleAddContainer.bind(this);
+    this.handleProjectSave = this.handleProjectSave.bind(this);
   }
 
   handleAddContainer() {
     this.props.addContainer();
+  }
+
+  handleProjectSave() {
+    const containers = this.props.usedContainers;
+    const components = this.props.usedComponents;
+    this.props.saveProject(components, containers);
   }
 
   render() {
@@ -23,6 +32,11 @@ export default class ButtonBar extends Component {
             label="Add Container"
             className="p-button-raised"
           />
+          <Button
+            label="Save"
+            className="p-button-rounded p-button-warning"
+            onClick={this.handleProjectSave}
+          />
           <div className="p-toolbar-group-right">
             <ClipButton />
           </div>
@@ -31,3 +45,19 @@ export default class ButtonBar extends Component {
     );
   }
 }
+
+const mapStateToProps = state => {
+  return {
+    usedContainers: state.containers,
+    usedComponents: state.usedComponents,
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    saveProject: (usedComponents, containers) =>
+      dispatch(saveProject(usedComponents, containers)),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ButtonBar);

--- a/client/components/MainPage.js
+++ b/client/components/MainPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { addContainer } from '../store';
 import Preview from './preview/Preview';
 import CodeBox from './CodeBox';
 import ListOfComponents from './list/componentSection';
@@ -15,21 +16,21 @@ const placeholderItem = {
 import ButtonBar from './ButtonBar';
 
 class MainPage extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      containers: [placeholderItem],
+      // containers: [placeholderItem],
     };
-    this.addContainer = this.addContainer.bind(this);
+    this.handleAddContainer = this.handleAddContainer.bind(this);
   }
 
-  addContainer() {
-    const containerLen = this.state.containers.length;
+  handleAddContainer() {
+    const containerLen = this.props.containers.length;
     let nextIdx;
     if (containerLen < 1) {
       nextIdx = '0';
     } else {
-      let lastIdx = this.state.containers[containerLen - 1].i;
+      let lastIdx = this.props.containers[containerLen - 1].i;
       nextIdx = `${parseInt(lastIdx) + 1}`;
     }
     console.log('clicking add container button');
@@ -40,15 +41,16 @@ class MainPage extends Component {
       w: 1,
       h: 2,
     };
-    this.setState(prevState => {
-      return { containers: [...prevState.containers, newItem] };
-    });
+    this.props.addContainer(newItem);
+    // this.setState(prevState => {
+    //   return { containers: [...prevState.containers, newItem] };
+    // });
   }
 
   render() {
     return (
       <div>
-        <ButtonBar addContainer={this.addContainer} />
+        <ButtonBar addContainer={this.handleAddContainer} />
         <div
           style={{
             display: 'grid',
@@ -57,7 +59,8 @@ class MainPage extends Component {
           }}
         >
           <ListOfComponents />
-          <Preview containers={this.state.containers} />
+          {/* <Preview containers={this.state.containers} /> */}
+          <Preview />
           <CodeBox key={this.props.code.length} code={this.props.code} />
         </div>
       </div>
@@ -68,8 +71,15 @@ class MainPage extends Component {
 const mapStateToProps = state => {
   return {
     components: state.component.allComponents,
+    containers: state.containers,
     code: '',
   };
 };
 
-export default connect(mapStateToProps)(MainPage);
+const mapDispatchToProps = dispatch => {
+  return {
+    addContainer: container => dispatch(addContainer(container)),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(MainPage);

--- a/client/components/ProfileProjects.js
+++ b/client/components/ProfileProjects.js
@@ -3,9 +3,14 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 // import { getAllProjects, getSingleProject } from '../store/projects';
 // import { getAllUsers, getSingleUser } from '../store/users';
-import { getSingleUser } from '../store/users';
+import { getSingleUser, getSavedProject } from '../store';
 
 class ProfileProjects extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleOpenProject = this.handleOpenProject.bind(this);
+  }
   // componentDidMount() {
   //   // this.props.getAllProjects(this.props.match.params.id);
   //   // this.props.getSingleProject(this.props.match.params);
@@ -16,6 +21,11 @@ class ProfileProjects extends Component {
   componentDidMount() {
     this.props.getSingleUser(this.props.match.params.id);
   }
+
+  handleOpenProject() {
+    this.props.getSavedProject();
+  }
+
   render() {
     const { user, userProjects } = this.props;
     console.log('state1', this.props);
@@ -29,6 +39,14 @@ class ProfileProjects extends Component {
               <ul key={p.id}>
                 <h3>Projects:</h3>
                 <h4>{p.title}</h4>
+                <button
+                  type="button"
+                  size="small"
+                  color="primary"
+                  onClick={this.handleOpenProject}
+                >
+                  OPEN
+                </button>
                 <button
                   type="button"
                   size="small"
@@ -71,6 +89,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     getSingleUser: id => dispatch(getSingleUser(id)),
+    getSavedProject: () => dispatch(getSavedProject()),
   };
 };
 

--- a/client/components/preview/Preview.js
+++ b/client/components/preview/Preview.js
@@ -5,7 +5,7 @@ import DropWrapper from './DropWrapper';
 import ContainerBox from './Container';
 import RGL, { WidthProvider } from 'react-grid-layout';
 import Generic from '../PreviewElements/Generic';
-import { updateCode } from '../../store';
+import { updateCode, saveContainers } from '../../store';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
@@ -42,7 +42,12 @@ class Preview extends Component {
     this.setDroppedElement = this.setDroppedElement.bind(this);
     this.createContainer = this.createContainer.bind(this);
     this.removeContainer = this.removeContainer.bind(this);
+    this.onResize = this.onResize.bind(this);
   }
+
+  onResize = layouts => {
+    this.props.saveContainers(layouts);
+  };
 
   removeContainer() {
     console.log('clicked remove container button');
@@ -146,6 +151,7 @@ class Preview extends Component {
 const mapDispatchToProps = dispatch => {
   return {
     updateCode: code => dispatch(updateCode(code)),
+    saveContainers: containers => dispatch(saveContainers(containers)),
   };
 };
 

--- a/client/components/preview/Preview.js
+++ b/client/components/preview/Preview.js
@@ -71,9 +71,9 @@ class Preview extends Component {
     }
   }
 
-  onResize = layouts => {
+  onResize(layouts) {
     this.props.saveContainers(layouts);
-  };
+  }
 
   removeContainer() {
     console.log('clicked remove container button');
@@ -153,20 +153,22 @@ class Preview extends Component {
             width={1200}
             cols={12}
             onResize={this.onResize}
-            layout={this.state.layout}
+            layout={this.props.usedContainers}
             onLayoutChange={this.onLayoutChange}
             draggableHandle=".MyDragHandleClassName"
             draggableCancel=".MyDragCancel"
           >
             {/* ABove hard codes example dragable elements but we will ultimately get these from parts of our state */}
-            {this.props.usedContainers.map((item, idx) => {
-              return this.createContainer(item);
-              // <div
-              //   className="MyDragHandleClassName"
-              //   key={idx + 1}
-              //   data-grid={item}
-              // />
-            })}
+            {this.props.usedContainers.length
+              ? this.props.usedContainers.map(item => {
+                  return this.createContainer(item);
+                  // <div
+                  //   className="MyDragHandleClassName"
+                  //   key={idx + 1}
+                  //   data-grid={item}
+                  // />
+                })
+              : null}
           </ReactGridLayout>
         </DropWrapper>
       </div>

--- a/client/components/preview/Preview.js
+++ b/client/components/preview/Preview.js
@@ -35,7 +35,7 @@ class Preview extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      layout: [...this.props.containers],
+      layout: this.props.containers,
       resizeplotly: false,
       code: '',
     };
@@ -133,7 +133,7 @@ class Preview extends Component {
             draggableCancel=".MyDragCancel"
           >
             {/* ABove hard codes example dragable elements but we will ultimately get these from parts of our state */}
-            {this.props.containers.map((item, idx) => {
+            {this.props.usedContainers.map((item, idx) => {
               return this.createContainer(item);
               // <div
               //   className="MyDragHandleClassName"
@@ -148,6 +148,12 @@ class Preview extends Component {
   }
 }
 
+const mapStateToProps = state => {
+  return {
+    usedContainers: state.containers,
+  };
+};
+
 const mapDispatchToProps = dispatch => {
   return {
     updateCode: code => dispatch(updateCode(code)),
@@ -155,4 +161,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(null, mapDispatchToProps)(Preview);
+export default connect(mapStateToProps, mapDispatchToProps)(Preview);

--- a/client/components/preview/Preview.js
+++ b/client/components/preview/Preview.js
@@ -8,6 +8,7 @@ import Generic from '../PreviewElements/Generic';
 import { updateCode, saveContainers } from '../../store';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
+import usedComponents from '../../store/usedComponents';
 
 const ReactGridLayout = WidthProvider(RGL);
 const isEmpty = obj => {
@@ -15,6 +16,23 @@ const isEmpty = obj => {
     if (obj.hasOwnProperty(key)) return false;
   }
   return true;
+};
+
+const populateSavedComponents = arr => {
+  const grid = document.querySelector('.react-grid-layout');
+
+  arr.map(obj => {
+    const { component, i } = obj;
+    console.log(component, i);
+    let node = document.createElement(component.tag);
+    node.textContent = component.content;
+    if (component.tag.toLowerCase() === 'img') {
+      node.src = component.src;
+    }
+    node.id = component.domId;
+    let container = grid.querySelector(`#\\3${i}`);
+    container.appendChild(node);
+  });
 };
 
 // item and MyDrageHandleClassName in css file
@@ -43,6 +61,14 @@ class Preview extends Component {
     this.createContainer = this.createContainer.bind(this);
     this.removeContainer = this.removeContainer.bind(this);
     this.onResize = this.onResize.bind(this);
+  }
+
+  componentDidMount() {
+    console.log('loading Preview area');
+    if (this.props.usedContainers.length > 0) {
+      console.log('loading used components');
+      populateSavedComponents(this.props.usedComponents);
+    }
   }
 
   onResize = layouts => {
@@ -151,6 +177,7 @@ class Preview extends Component {
 const mapStateToProps = state => {
   return {
     usedContainers: state.containers,
+    usedComponents: state.usedComponents,
   };
 };
 

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -7,12 +7,11 @@ import { Link } from 'react-router-dom';
  * COMPONENT
  */
 export const UserHome = props => {
-  const { displayName, id, email } = props;
+  const { displayName, id, email } = props.user;
 
   return (
     <div>
-      <h3>Welcome, {email}</h3>
-      {/* <h3>Welcome, {displayName}</h3> */}
+      <h3>Welcome, {displayName}</h3>
 
       <section className="userhome-container">
         <div className="userhome-nav-selection">
@@ -34,7 +33,7 @@ export const UserHome = props => {
  */
 const mapState = state => {
   return {
-    displayName: state.user.displayName,
+    user: state.user,
   };
 };
 

--- a/client/store/code.js
+++ b/client/store/code.js
@@ -19,7 +19,8 @@ const updatedCode = code => ({
 
 export const updateCode = code => {
   return dispatch => {
-    const prettyCode = beautify.html(code);
+    const fullCode = openHtml + code + closeHtml;
+    const prettyCode = beautify.html(fullCode);
     try {
       dispatch(updatedCode(prettyCode));
       console.log('new code is ', prettyCode);
@@ -40,12 +41,7 @@ export const updateCode = code => {
   }
 }
 
-// const openHtml = '<!DOCTYPE html>
-// <html>
-//   <head>
-//     <meta charset='utf-8'>
-//     <meta name='viewport' content='width=device-width initial-scale=1.0'>
-//     <title>Your Code</title>
-//   </head><body>'
+const openHtml =
+  "<!DOCTYPE html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width initial-scale=1.0'><title>Your Code</title></head><body>";
 
-// const closeHtml = '</body></html>'
+const closeHtml = '</body></html>';

--- a/client/store/code.js
+++ b/client/store/code.js
@@ -4,7 +4,7 @@ import beautify from 'js-beautify';
  * ACTION TYPES
  */
 const UPDATE_CODE = 'UPDATE_CODE';
-
+const CLEAR_CODE = 'CLEAR_CODE';
 /**
  * ACTION CREATORS
  */
@@ -13,6 +13,7 @@ const updatedCode = code => ({
   code,
 });
 
+export const clearedCode = () => ({ type: CLEAR_CODE });
 /**
  * THUNK CREATORS
  */
@@ -36,6 +37,8 @@ export const updateCode = code => {
   switch (action.type) {
     case UPDATE_CODE:
       return action.code;
+    case CLEAR_CODE:
+      return '';
     default:
       return code;
   }

--- a/client/store/containers.js
+++ b/client/store/containers.js
@@ -1,0 +1,37 @@
+/**
+ * ACTION TYPES
+ */
+const SAVE_CONTAINERS = 'SAVE_CONTAINERS';
+
+/**
+ * ACTION CREATORS
+ */
+const savedContainers = containers => ({
+  type: SAVE_CONTAINERS,
+  containers,
+});
+
+/**
+ * THUNK CREATORS
+ */
+export const saveContainers = containers => {
+  return dispatch => {
+    try {
+      dispatch(savedContainers(containers));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+};
+
+/**
+ * REDUCER
+ */
+export default function containers(containers = [], action) {
+  switch (action.type) {
+    case SAVE_CONTAINERS:
+      return action.containers;
+    default:
+      return containers;
+  }
+}

--- a/client/store/containers.js
+++ b/client/store/containers.js
@@ -2,13 +2,18 @@
  * ACTION TYPES
  */
 const SAVE_CONTAINERS = 'SAVE_CONTAINERS';
-
+const ADD_CONTAINER = 'ADD_CONTAINER';
 /**
  * ACTION CREATORS
  */
 const savedContainers = containers => ({
   type: SAVE_CONTAINERS,
   containers,
+});
+
+const addedContainer = container => ({
+  type: ADD_CONTAINER,
+  container,
 });
 
 /**
@@ -24,6 +29,16 @@ export const saveContainers = containers => {
   };
 };
 
+export const addContainer = container => {
+  return dispatch => {
+    try {
+      dispatch(addedContainer(container));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+};
+
 /**
  * REDUCER
  */
@@ -31,6 +46,8 @@ export default function containers(containers = [], action) {
   switch (action.type) {
     case SAVE_CONTAINERS:
       return action.containers;
+    case ADD_CONTAINER:
+      return [...containers, action.container];
     default:
       return containers;
   }

--- a/client/store/containers.js
+++ b/client/store/containers.js
@@ -3,6 +3,8 @@
  */
 const SAVE_CONTAINERS = 'SAVE_CONTAINERS';
 const ADD_CONTAINER = 'ADD_CONTAINER';
+const GOT_SAVED_CONTAINERS = 'GOT_SAVED_CONTAINERS';
+const CLEAR_CONTAINERS = 'CLEAR_CONTAINERS';
 /**
  * ACTION CREATORS
  */
@@ -14,6 +16,13 @@ const savedContainers = containers => ({
 const addedContainer = container => ({
   type: ADD_CONTAINER,
   container,
+});
+
+export const clearedContainers = () => ({ type: CLEAR_CONTAINERS });
+
+export const gotSavedContainers = containers => ({
+  type: GOT_SAVED_CONTAINERS,
+  containers,
 });
 
 /**
@@ -48,6 +57,10 @@ export default function containers(containers = [], action) {
       return action.containers;
     case ADD_CONTAINER:
       return [...containers, action.container];
+    case GOT_SAVED_CONTAINERS:
+      return action.containers;
+    case CLEAR_CONTAINERS:
+      return [];
     default:
       return containers;
   }

--- a/client/store/currentProject.js
+++ b/client/store/currentProject.js
@@ -1,0 +1,48 @@
+import axios from 'axios';
+/**
+ * ACTION TYPES
+ */
+const SAVE_PROJECT = 'SAVE_PROJECT';
+
+/**
+ * ACTION CREATORS
+ */
+const savedProject = projObj => ({
+  type: SAVE_PROJECT,
+  projObj,
+});
+
+/**
+ * THUNK CREATORS
+ */
+export const saveProject = (
+  components,
+  containers,
+  projId = 1
+) => async dispatch => {
+  const usedComponents = JSON.stringify(components);
+  const usedContainers = JSON.stringify(containers);
+  try {
+    console.log('SAVING PROJECT');
+    const { data } = await axios.put(`/api/projects/${projId}`, {
+      usedComponents,
+      usedContainers,
+    });
+    console.log('saved dta is ', data);
+    dispatch(savedProject({ usedComponents, usedContainers }));
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/**
+ * REDUCER
+ */
+export default function usedComponents(project = {}, action) {
+  switch (action.type) {
+    case SAVE_PROJECT:
+      return action.projObj;
+    default:
+      return project;
+  }
+}

--- a/client/store/currentProject.js
+++ b/client/store/currentProject.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import history from '../history';
-import { gotSavedComponents, gotSavedContainers } from './index';
+import { gotSavedComponents } from './usedComponents';
+import { gotSavedContainers } from './containers';
 /**
  * ACTION TYPES
  */

--- a/client/store/currentProject.js
+++ b/client/store/currentProject.js
@@ -1,15 +1,27 @@
 import axios from 'axios';
+import history from '../history';
+import { gotSavedComponents, gotSavedContainers } from './index';
 /**
  * ACTION TYPES
  */
 const SAVE_PROJECT = 'SAVE_PROJECT';
-
+const GET_SAVED_PROJECT = 'GET_SAVED_PROJECT';
+const CLEAR_PROJECT = 'CLEAR_PROJECT';
 /**
  * ACTION CREATORS
  */
 const savedProject = projObj => ({
   type: SAVE_PROJECT,
   projObj,
+});
+
+const gotSavedProject = projObj => ({
+  type: GET_SAVED_PROJECT,
+  projObj,
+});
+
+export const clearedProject = () => ({
+  type: CLEAR_PROJECT,
 });
 
 /**
@@ -35,13 +47,43 @@ export const saveProject = (
   }
 };
 
+export const getSavedProject = () => {
+  return async dispatch => {
+    try {
+      // remove hard coded proj ID
+      const { data } = await axios.get('/api/projects/1');
+      const { usedContainers, usedComponents } = data;
+      console.log('saved data is ', usedContainers, usedComponents);
+      dispatch(
+        gotSavedProject({
+          usedComponents: JSON.parse(usedComponents),
+          containers: JSON.parse(usedContainers),
+        })
+      );
+      dispatch(gotSavedContainers(JSON.parse(usedContainers)));
+      dispatch(gotSavedComponents(JSON.parse(usedComponents)));
+      history.push('/mainPage');
+    } catch (error) {
+      console.error(error);
+    }
+  };
+};
+
 /**
  * REDUCER
  */
-export default function usedComponents(project = {}, action) {
+const defaultProj = {
+  usedComponents: {},
+  usedContainers: {},
+};
+export default function usedComponents(project = defaultProj, action) {
   switch (action.type) {
     case SAVE_PROJECT:
       return action.projObj;
+    case GET_SAVED_PROJECT:
+      return action.projObj;
+    case CLEAR_PROJECT:
+      return defaultProj;
     default:
       return project;
   }

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -8,6 +8,8 @@ import code from './code';
 import users from './users';
 import projects from './projects';
 import usedComponents from './usedComponents';
+import currentProject from './currentProject';
+import containers from './containers';
 
 const reducer = combineReducers({
   user,
@@ -16,6 +18,8 @@ const reducer = combineReducers({
   code,
   users,
   projects,
+  currentProject,
+  containers,
 });
 
 const middleware = composeWithDevTools(
@@ -30,3 +34,5 @@ export * from './code';
 export * from './users';
 export * from './projects';
 export * from './usedComponents';
+export * from './currentProject';
+export * from './containers';

--- a/client/store/usedComponents.js
+++ b/client/store/usedComponents.js
@@ -2,6 +2,7 @@
  * ACTION TYPES
  */
 const ADD_COMPONENT = 'ADD_COMPONENT';
+const GOT_SAVED_COMPONENTS = 'GOT_SAVED_COMPONENTS';
 
 /**
  * ACTION CREATORS
@@ -9,6 +10,11 @@ const ADD_COMPONENT = 'ADD_COMPONENT';
 const addedComponent = componentObj => ({
   type: ADD_COMPONENT,
   componentObj,
+});
+
+export const gotSavedComponents = components => ({
+  type: GOT_SAVED_COMPONENTS,
+  components,
 });
 
 /**
@@ -35,6 +41,8 @@ export default function usedComponents(components = [], action) {
   switch (action.type) {
     case ADD_COMPONENT:
       return [...components, action.componentObj];
+    case GOT_SAVED_COMPONENTS:
+      return action.components;
     default:
       return components;
   }

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import history from '../history';
-import { clearedProject, clearedContainers } from './index';
+import { clearedProject } from './currentProject';
+import { clearedContainers } from './containers';
 /**
  * ACTION TYPES
  */

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import history from '../history';
-
+import { clearedProject, clearedContainers } from './index';
 /**
  * ACTION TYPES
  */
@@ -61,6 +61,8 @@ export const logout = () => async dispatch => {
   try {
     await axios.post('/auth/logout');
     dispatch(removeUser());
+    dispatch(clearedProject());
+    dispatch(clearedContainers());
     history.push('/login');
   } catch (err) {
     console.error(err);

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import history from '../history';
 import { clearedProject } from './currentProject';
 import { clearedContainers } from './containers';
+import { clearedCode } from './code';
 /**
  * ACTION TYPES
  */
@@ -64,6 +65,7 @@ export const logout = () => async dispatch => {
     dispatch(removeUser());
     dispatch(clearedProject());
     dispatch(clearedContainers());
+    dispatch(clearedCode());
     history.push('/login');
   } catch (err) {
     console.error(err);

--- a/server/db/models/project.js
+++ b/server/db/models/project.js
@@ -15,6 +15,12 @@ const Project = db.define('project', {
   externalUrl: {
     type: Sequelize.TEXT,
   },
+  usedContainers: {
+    type: Sequelize.TEXT,
+  },
+  usedComponents: {
+    type: Sequelize.TEXT,
+  },
 });
 
 module.exports = Project;


### PR DESCRIPTION
CodeMirror: add opening and closing html to help with formatting

Put Preview component's React-Grid-Layout grid into state
- adding containers, resizing containers are all attached to actions which update the array of container objects in Redux that allow the Preview to map out the blue containers

Save Projects
- add Save button
- add currentProject to Redux to handle project state 
- usedComponents added to Redux state to handle data in used components 
- usedContainers added to Redux state to handle containers and their data used in project

Load Projects
- add thunk (hardcoded to proj id 1) to fetch saved data 
- add usedComponents and usedContainers to be text in Project Sequelize model.  Data is a stringified JSON object
- add a parsing function to generate components in DOM if we have loaded components from a project

Logout
- add actions to ensure loaded project is cleared from state when user logs out