### PR TITLE
fix(template-enginer): fix for the template engine

### DIFF
--- a/client/components/BlogTemplate.js
+++ b/client/components/BlogTemplate.js
@@ -14,6 +14,7 @@ class BlogTemplate extends Component {
     this.state = {};
     this.handleAddContainer = this.handleAddContainer.bind(this);
   }
+
   componentDidMount() {
     // check to see if any containers already exist - if not, make one
     if (!this.props.containers.length > 0) {


### PR DESCRIPTION
Moves component did mount out of the React class constructor
Should prevent template engine from crashing on load.
